### PR TITLE
Updated Readme, changes to make work with latest Home Assistant, some suggestions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Wavin Sentio for Home Assistant
 
 ## Requirements
-TODO
+Wavin Sentio CCU-208 controller running a recent firmware (tested with FW18)
 
 ## Installation
-TODO
+Open https://portal.wavinsentio.com/devices and add your system there. Use the new (FW18+) remote management feature to enable modbus. (Older versions can use the dedicated control box or the older desktop software to connect).
+
+Go to system --> Installer settings --> Modbus configuration --> Sentio Modbus TCP
+TCP Mode: Slave Read/Write
+Note the IP and port number (often 502)
+
+Add this module to your Home Assistant setup (use of HACS recommended) and restart Home Assistant. Go to integrations and Add Integration, Wavin Sentio Modbus.
+Enter your IP number of the CCU and port number (often 502). Slave 1 works fine.
+
+The addon should show a new device with all the subdevices (rooms). It's read/write so you should be able to set the modes/temperatures.

--- a/custom_components/wavinsentiomodbus/__init__.py
+++ b/custom_components/wavinsentiomodbus/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
     #    raise ConfigEntryAuthFailed(err) from err
 
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
+        hass.config_entries.async_forward_entry_setups(entry, ["climate"])
     )
 
     return True

--- a/custom_components/wavinsentiomodbus/config_flow.py
+++ b/custom_components/wavinsentiomodbus/config_flow.py
@@ -64,7 +64,7 @@ class WavinSentioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema(
             {
                 vol.Required(CONF_HOST, default="192.168.188.14", description="host"): str, #TODO REMOVE DEFAULT
-                vol.Required(CONF_PORT, default=512, description="port"): int,
+                vol.Required(CONF_PORT, default=502, description="port"): int,
                 vol.Required(CONF_SLAVE, default=1, description="slave"): int,
             }
         )

--- a/custom_components/wavinsentiomodbus/const.py
+++ b/custom_components/wavinsentiomodbus/const.py
@@ -1,7 +1,7 @@
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "wavinsentio"
+DOMAIN = "wavinsentiomodbus"
 
 CONF_LOCATION_ID = "ULC"
 

--- a/custom_components/wavinsentiomodbus/manifest.json
+++ b/custom_components/wavinsentiomodbus/manifest.json
@@ -4,8 +4,8 @@
   "dependencies": [],
   "documentation": "https://github.com/stefboerrigter/wavinsentio-ha",
   "issue_tracker": "https://github.com/stefboerrigter/wavinsentio-ha/issues",
-  "domain": "wavinsentio",
-  "name": "Wavin Sentio",
+  "domain": "wavinsentiomodbus",
+  "name": "Wavin Sentio Modbus",
   "requirements": ["WavinSentioModbus == 0.9.0"],
   "version": "0.2.1",
   "iot_class": "local_polling"


### PR DESCRIPTION
The other web-based Sentio plugin is broken so I invested a little bit of time to update this modbus version to work with my current setup. Proposed changes:

- Updated the readme,
- Bugbix: changed config_entries.async_forward_entry_setups (config_entries.async_forward_entry_setup is removed from HA)
- Change default port to 502
- Changed logging/manifest domain to not clash with other Sentio modules

Hope this works for you as well.